### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -7,7 +7,7 @@
     "OpenSSL"
   ],
   "description": "PKCS #5 with PBKDF2",
-  "license": "The Artistic License 2.0",
+  "license": "Artistic-2.0",
   "name": "PKCS5",
   "perl": "6.c",
   "provides": {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license